### PR TITLE
ignore empty schema name

### DIFF
--- a/src/main/java/liquibase/ext/maxdb/sqlgenerator/GetViewDefinitionGeneratorMaxDB.java
+++ b/src/main/java/liquibase/ext/maxdb/sqlgenerator/GetViewDefinitionGeneratorMaxDB.java
@@ -24,8 +24,14 @@ public class GetViewDefinitionGeneratorMaxDB extends GetViewDefinitionGenerator 
     public Sql[] generateSql(GetViewDefinitionStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
         CatalogAndSchema schema = database.correctSchema(new CatalogAndSchema(statement.getCatalogName(), statement.getSchemaName()));
 
-        return new Sql[]{
-                new UnparsedSql("SELECT DEFINITION FROM DOMAIN.VIEWDEFS WHERE upper(VIEWNAME)='" + statement.getViewName().toUpperCase() + "' AND OWNER='" + schema.getSchemaName() + "'")
-        };
+        if (schema.getSchemaName() != null) {
+	        return new Sql[]{
+	                new UnparsedSql("SELECT DEFINITION FROM DOMAIN.VIEWDEFS WHERE upper(VIEWNAME)='" + statement.getViewName().toUpperCase() + "' AND OWNER='" + schema.getSchemaName() + "'")
+	        };
+        } else {
+	        return new Sql[]{
+	                new UnparsedSql("SELECT DEFINITION FROM DOMAIN.VIEWDEFS WHERE upper(VIEWNAME)='" + statement.getViewName().toUpperCase() + "'")
+	        };        	
+        }
     }
 }


### PR DESCRIPTION
MaxDBDatabase overrides supportsSchema() to return false. This causes GetViewDefinitionGeneratorMaxDB#generateSql to fail because it receives NULL as the schema name. The code below selects without giving a schema name.
