### PR TITLE
DROP INDEX statement for MaxDB corrected

### DIFF
--- a/src/main/java/liquibase/ext/maxdb/sqlgenerator/DropIndexGeneratorMaxDB.java
+++ b/src/main/java/liquibase/ext/maxdb/sqlgenerator/DropIndexGeneratorMaxDB.java
@@ -1,0 +1,32 @@
+package liquibase.ext.maxdb.sqlgenerator;
+
+import liquibase.database.Database;
+import liquibase.exception.ValidationErrors;
+import liquibase.sql.Sql;
+import liquibase.sql.UnparsedSql;
+import liquibase.sqlgenerator.SqlGeneratorChain;
+import liquibase.sqlgenerator.core.DropIndexGenerator;
+import liquibase.statement.core.DropIndexStatement;
+
+public class DropIndexGeneratorMaxDB extends DropIndexGenerator {
+
+    @Override
+    public ValidationErrors validate(DropIndexStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+        ValidationErrors validationErrors = new ValidationErrors();
+        validationErrors.checkRequiredField("indexName", statement.getIndexName());
+        validationErrors.checkRequiredField("tableName", statement.getTableName());
+        return validationErrors;
+    }
+
+    @Override
+    public Sql[] generateSql(DropIndexStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
+    	Sql[] parentSql = super.generateSql(statement, database, sqlGeneratorChain);
+    	if (parentSql.length == 0)
+    		// associatedWith - fallbacks
+    		return parentSql;
+
+        String schemaName = statement.getTableSchemaName();
+        return new Sql[] {new UnparsedSql("DROP INDEX " + database.escapeIndexName(null, null, statement.getIndexName()) + " ON " + database.escapeTableName(statement.getTableCatalogName(), schemaName, statement.getTableName()), getAffectedIndex(statement)) };
+    }
+
+}

--- a/src/main/java/liquibase/ext/maxdb/sqlgenerator/DropIndexGeneratorMaxDB.java
+++ b/src/main/java/liquibase/ext/maxdb/sqlgenerator/DropIndexGeneratorMaxDB.java
@@ -1,14 +1,21 @@
 package liquibase.ext.maxdb.sqlgenerator;
 
+import java.util.List;
+
 import liquibase.database.Database;
+import liquibase.database.core.MSSQLDatabase;
+import liquibase.database.core.OracleDatabase;
 import liquibase.exception.ValidationErrors;
 import liquibase.sql.Sql;
 import liquibase.sql.UnparsedSql;
 import liquibase.sqlgenerator.SqlGeneratorChain;
-import liquibase.sqlgenerator.core.DropIndexGenerator;
+import liquibase.sqlgenerator.core.AbstractSqlGenerator;
 import liquibase.statement.core.DropIndexStatement;
+import liquibase.structure.core.Index;
+import liquibase.structure.core.Table;
+import liquibase.util.StringUtils;
 
-public class DropIndexGeneratorMaxDB extends DropIndexGenerator {
+public class DropIndexGeneratorMaxDB extends AbstractSqlGenerator<DropIndexStatement> {
 
     @Override
     public ValidationErrors validate(DropIndexStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
@@ -20,13 +27,28 @@ public class DropIndexGeneratorMaxDB extends DropIndexGenerator {
 
     @Override
     public Sql[] generateSql(DropIndexStatement statement, Database database, SqlGeneratorChain sqlGeneratorChain) {
-    	Sql[] parentSql = super.generateSql(statement, database, sqlGeneratorChain);
-    	if (parentSql.length == 0)
-    		// associatedWith - fallbacks
-    		return parentSql;
+        List<String> associatedWith = StringUtils.splitAndTrim(statement.getAssociatedWith(), ",");
+        if (associatedWith != null) {
+            if (associatedWith.contains(Index.MARK_PRIMARY_KEY)|| associatedWith.contains(Index.MARK_UNIQUE_CONSTRAINT)) {
+                return new Sql[0];
+            } else if (associatedWith.contains(Index.MARK_FOREIGN_KEY) ) {
+                if (!(database instanceof OracleDatabase || database instanceof MSSQLDatabase)) {
+                    return new Sql[0];
+                }
+            }
+        }
 
         String schemaName = statement.getTableSchemaName();
-        return new Sql[] {new UnparsedSql("DROP INDEX " + database.escapeIndexName(null, null, statement.getIndexName()) + " ON " + database.escapeTableName(statement.getTableCatalogName(), schemaName, statement.getTableName()), getAffectedIndex(statement)) };
+        return new Sql[] {new UnparsedSql("DROP INDEX " + database.escapeIndexName(null, null, statement.getIndexName()) + 
+			" ON " + database.escapeTableName(statement.getTableCatalogName(), schemaName, statement.getTableName()), getAffectedIndex(statement)) };
+    }
+
+    protected Index getAffectedIndex(DropIndexStatement statement) {
+        Table table = null;
+        if (statement.getTableName() != null) {
+            table = (Table) new Table().setName(statement.getTableName()).setSchema(statement.getTableCatalogName(), statement.getTableSchemaName());
+        }
+        return new Index().setName(statement.getIndexName()).setTable(table);
     }
 
 }


### PR DESCRIPTION
The default version does not add the "ON <tableName>" clause, therefore requiring unique index names. My patch adds this clause and allows for dropping indices with the same name on different tables.
