### PR TITLE
Bugfix MaxDB Driver: In reality no catalog support

### DIFF
--- a/src/main/java/liquibase/ext/maxdb/database/MaxDBDatabase.java
+++ b/src/main/java/liquibase/ext/maxdb/database/MaxDBDatabase.java
@@ -1,15 +1,14 @@
 package liquibase.ext.maxdb.database;
 
 
-import liquibase.CatalogAndSchema;
+import java.util.HashSet;
+import java.util.Set;
+
 import liquibase.database.AbstractJdbcDatabase;
 import liquibase.database.DatabaseConnection;
 import liquibase.exception.DatabaseException;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.View;
-
-import java.util.HashSet;
-import java.util.Set;
 
 
 public class MaxDBDatabase extends AbstractJdbcDatabase {
@@ -165,6 +164,11 @@ public class MaxDBDatabase extends AbstractJdbcDatabase {
     @Override
     public boolean supportsTablespaces() {
         return false;
+    }
+    
+    @Override
+    public boolean supportsCatalogs() {
+    	return false;
     }
 
     @Override


### PR DESCRIPTION
I needed this change for the newer liquibase versions 3.6.x to work with the MaxDB.
Without this change, the DATABASECHANGELOG table is not recognized.
This was working in v3.3.x.