### PR TITLE
DAT-16149 DevOps :: Extensions Release Failing

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -8,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.5.5
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     nightly-build:
-      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.3
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
       with:
         nightly: true
       secrets: inherit

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   codeql:
-    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/codeql.yml@v0.5.5
     secrets: inherit
     with:
       languages: '["java"]'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,5 +8,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.5.5
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.5.5
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.3
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
     secrets: inherit
 
   integration-test:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-parent-pom</artifactId>
-        <version>0.2.6</version> <!-- Replace with the desired version -->
+        <version>0.3.1</version> <!-- Replace with the desired version -->
     </parent>
 
     <groupId>org.liquibase.ext</groupId>
@@ -40,6 +40,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <scm>
+        <connection>scm:git:${project.scm.url}</connection>
+        <developerConnection>scm:git:${project.scm.url}</developerConnection>
+		<url>https://github.com/liquibase/liquibase-maxdb.git</url>
+		<tag>HEAD</tag>
+	</scm>
 
     <build>
         <plugins>


### PR DESCRIPTION
chore(attach-artifact-release.yml): update build-logic extension version to v0.5.5

chore(build-nightly.yml): update os-extension-test extension version to v0.5.5
chore(codeql.yml): update codeql extension version to v0.5.5
chore(create-release.yml): update create-release extension version to v0.5.5
chore(release-published.yml): update extension-release-published extension version to v0.5.5
chore(test.yml): update os-extension-test extension version to v0.5.5
chore(pom.xml): update liquibase-parent-pom version to 0.3.1 and add scm configuration for git repository