### PR TITLE
fix: add missing replaces method for Snapshot Generator

### DIFF
--- a/src/main/java/liquibase/ext/maxdb/snapshot/SequenceSnapshotGeneratorMaxDB.java
+++ b/src/main/java/liquibase/ext/maxdb/snapshot/SequenceSnapshotGeneratorMaxDB.java
@@ -2,9 +2,10 @@ package liquibase.ext.maxdb.snapshot;
 
 import liquibase.database.Database;
 import liquibase.ext.maxdb.database.MaxDBDatabase;
+import liquibase.snapshot.SnapshotGenerator;
 import liquibase.snapshot.jvm.SequenceSnapshotGenerator;
 import liquibase.statement.SqlStatement;
-import liquibase.statement.core.RawSqlStatement;
+import liquibase.statement.core.RawParameterizedSqlStatement;
 import liquibase.structure.DatabaseObject;
 import liquibase.structure.core.Schema;
 
@@ -21,8 +22,13 @@ public class SequenceSnapshotGeneratorMaxDB extends SequenceSnapshotGenerator {
     @Override
     protected SqlStatement getSelectSequenceStatement(Schema schema, Database database) {
         if (database instanceof MaxDBDatabase) {
-            return new RawSqlStatement("SELECT SEQUENCE_NAME FROM DOMAIN.SEQUENCES WHERE OWNER = '" + schema.getName() + "'");
+            return new RawParameterizedSqlStatement("SELECT SEQUENCE_NAME FROM DOMAIN.SEQUENCES WHERE OWNER = '" + schema.getName() + "'");
         }
         return super.getSelectSequenceStatement(schema, database);
+    }
+
+    @Override
+    public Class<? extends SnapshotGenerator>[] replaces() {
+        return new Class[]{SequenceSnapshotGenerator.class};
     }
 }


### PR DESCRIPTION
liquibase/liquibase#5775 was merged and fixed a bug where some snapshot generators were not being called.
But it also highlighted one issue at least in one OSS extension: if then extension replaces a core generator but is not implementing the replaces method, both generators may be invoked now.

This PR implements the missing replaces method.